### PR TITLE
Extend the size_t conversion to include zlib, deflateBounds and crc32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -760,6 +760,7 @@ TEST_BUILTINS_OBJS += test-xml-encode.o
 TEST_BUILTINS_OBJS += test-wildmatch.o
 TEST_BUILTINS_OBJS += test-windows-named-pipe.o
 TEST_BUILTINS_OBJS += test-write-cache.o
+TEST_BUILTINS_OBJS += test-zlib-compile-flags.o
 
 # Do not add more tests here unless they have extra dependencies. Add
 # them in TEST_BUILTINS_OBJS above.

--- a/archive-zip.c
+++ b/archive-zip.c
@@ -352,7 +352,7 @@ static int write_zip_entry(struct archiver_args *args,
 			if (!buffer)
 				return error(_("cannot read %s"),
 					     oid_to_hex(oid));
-			crc = crc32(crc, buffer, size);
+			crc = xcrc32(crc, buffer, size);
 			is_binary = entry_is_binary(args->repo->index,
 						    path_without_prefix,
 						    buffer, size);
@@ -428,7 +428,7 @@ static int write_zip_entry(struct archiver_args *args,
 			readlen = read_istream(stream, buf, sizeof(buf));
 			if (readlen <= 0)
 				break;
-			crc = crc32(crc, buf, readlen);
+			crc = xcrc32(crc, buf, readlen);
 			if (is_binary == -1)
 				is_binary = entry_is_binary(args->repo->index,
 							    path_without_prefix,
@@ -461,7 +461,7 @@ static int write_zip_entry(struct archiver_args *args,
 			readlen = read_istream(stream, buf, sizeof(buf));
 			if (readlen <= 0)
 				break;
-			crc = crc32(crc, buf, readlen);
+			crc = xcrc32(crc, buf, readlen);
 			if (is_binary == -1)
 				is_binary = entry_is_binary(args->repo->index,
 							    path_without_prefix,

--- a/archive-zip.c
+++ b/archive-zip.c
@@ -186,13 +186,13 @@ static uint32_t clamp32(uintmax_t n)
 	const uintmax_t max = 0xffffffff;
 	return (n < max) ? n : max;
 }
-
+/// FIXME unsigned long
 static void *zlib_deflate_raw(void *data, unsigned long size,
 			      int compression_level,
 			      unsigned long *compressed_size)
 {
 	git_zstream stream;
-	unsigned long maxsize;
+	size_t maxsize;
 	void *buffer;
 	int result;
 

--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -255,7 +255,7 @@ static uint64_t total_ram(void)
 
 static uint64_t estimate_repack_memory(struct packed_git *pack)
 {
-	unsigned long nr_objects = approximate_object_count();
+	size_t nr_objects = approximate_object_count();
 	size_t os_cache, heap;
 
 	if (!pack || !nr_objects)

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -444,7 +444,7 @@ static void *unpack_entry_data(off_t offset, size_t size,
 	memset(&stream, 0, sizeof(stream));
 	git_inflate_init(&stream);
 	stream.next_out = buf;
-	stream.avail_out = buf == fixed_buf ? sizeof(fixed_buf) : zlib_buf_cap(size);
+	stream.avail_out = buf == fixed_buf ? sizeof(fixed_buf) : size;
 
 	do {
 		
@@ -467,7 +467,9 @@ static void *unpack_entry_data(off_t offset, size_t size,
 	} while (status == Z_OK);
 	if (stream.total_out != size)
 		// BUGS OUT HERE
-		printf("stream.total_out %zu != size %zu \n",  stream.total_out, size);
+		fprintf(stderr,"stream.total_out %"PRIuMAX" != size %"PRIuMAX" \n",  stream.total_out, size);
+		printf("***\n");
+		fflush(stdout);
 		bad_object(offset, _("stream.total_out != size: inflate returned %d"), status);
 	if (status != Z_STREAM_END)
 		// BUGS OUT HERE
@@ -486,7 +488,7 @@ static void *unpack_raw_entry(struct object_entry *obj,
 	unsigned char *p;
 	size_t size, c;
 	off_t base_offset;
-	unsigned shift;
+	size_t shift;
 	void *data;
 
 	obj->idx.offset = consumed_bytes;

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -455,9 +455,12 @@ static void *unpack_entry_data(off_t offset, size_t size,
 			stream.avail_out = sizeof(fixed_buf);
 		}
 	} while (status == Z_OK);
-	if (stream.total_out != size || status != Z_STREAM_END)
+	if (stream.total_out != size)
 		// BUGS OUT HERE
-		bad_object(offset, _("inflate returned %d"), status);
+		bad_object(offset, _("stream.total_out != size: inflate returned %d"), status);
+	if (status != Z_STREAM_END)
+		// BUGS OUT HERE
+		bad_object(offset, _("status != Z_STREAM_END: inflate returned %d"), status);
 	git_inflate_end(&stream);
 	if (oid)
 		the_hash_algo->final_fn(oid->hash, &c);

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -272,18 +272,11 @@ static void *fill(size_t min)
 
 static void use(size_t bytes)
 {
-	size_t bytes_rem;
 	if (bytes > input_len)
 		die(_("used more bytes than were available"));
-	bytes_rem = bytes;
-
-	while (bytes_rem > INTMAX_MAX) {
-		int crc_bytes = (bytes_rem > INTMAX_MAX) ? INTMAX_MAX : bytes_rem;
-		input_crc32 = crc32(input_crc32, input_buffer + input_offset, crc_bytes);
-		input_len -= crc_bytes;
-		input_offset += crc_bytes;
-		bytes_rem -= crc_bytes;
-	}
+	input_crc32 = xcrc32(input_crc32, input_buffer + input_offset, bytes);
+	input_len -= bytes;
+	input_offset += bytes;
 
 	/* make sure off_t is sufficiently large not to wrap */
 	if (signed_add_overflows(consumed_bytes, bytes))

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -456,6 +456,7 @@ static void *unpack_entry_data(off_t offset, size_t size,
 		}
 	} while (status == Z_OK);
 	if (stream.total_out != size || status != Z_STREAM_END)
+		// BUGS OUT HERE
 		bad_object(offset, _("inflate returned %d"), status);
 	git_inflate_end(&stream);
 	if (oid)

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -250,8 +250,8 @@ static void *fill(size_t min)
 	if (min <= input_len)
 		return input_buffer + input_offset;
 	if (min > sizeof(input_buffer))
-		die(Q_("cannot fill %PRIuMAX byte",
-		       "cannot fill %d bytes",
+		die(Q_("cannot fill %"PRIuMAX" byte",
+		       "cannot fill %"PRIuMAX" bytes",
 		       (uintmax_t) min),
 		    (uintmax_t) min);
 	flush();

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -435,12 +435,12 @@ static void *unpack_entry_data(off_t offset, size_t size,
 	if (type == OBJ_BLOB && size > big_file_threshold)
 		buf = fixed_buf;
 	else
-		buf = xmallocz(size);
+		buf = xmallocz(zlib_buf_cap(size));
 
 	memset(&stream, 0, sizeof(stream));
 	git_inflate_init(&stream);
 	stream.next_out = buf;
-	stream.avail_out = buf == fixed_buf ? sizeof(fixed_buf) : size;
+	stream.avail_out = buf == fixed_buf ? sizeof(fixed_buf) : zlib_buf_cap(size);
 
 	do {
 		unsigned char *last_out = stream.next_out;

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -423,6 +423,8 @@ static void *unpack_entry_data(off_t offset, size_t size,
 	char hdr[32];
 	int hdrlen;
 
+	printf("blob size %" PRIuMAX "\n", (uintmax_t)size);
+
 	if (!is_delta_type(type)) {
 		hdrlen = xsnprintf(hdr, sizeof(hdr), "%s %"PRIuMAX,
 				   type_name(type),(uintmax_t)size) + 1;

--- a/builtin/unpack-objects.c
+++ b/builtin/unpack-objects.c
@@ -440,7 +440,7 @@ static void unpack_delta_entry(enum object_type type, size_t delta_size,
 
 static void unpack_one(unsigned nr)
 {
-	unsigned shift;
+	size_t shift;
 	unsigned char *pack;
 	size_t size, c;
 	enum object_type type;

--- a/builtin/unpack-objects.c
+++ b/builtin/unpack-objects.c
@@ -79,7 +79,7 @@ static void *fill(int min)
 	return buffer;
 }
 
-static void use(int bytes)
+static void use(size_t bytes)
 {
 	if (bytes > len)
 		die("used more bytes than were available");

--- a/cache.h
+++ b/cache.h
@@ -1860,4 +1860,10 @@ extern int print_sha1_ellipsis(void);
 /* Return 1 if the file is empty or does not exists, 0 otherwise. */
 extern int is_empty_or_missing_file(const char *filename);
 
+/*
+ * Extended crc32 with 64 bit address range
+ * On Windows, uInt/uLong are only 32 bits.
+ */
+extern uLong xcrc32(uLong crc, const unsigned char *buf, size_t bytes);
+
 #endif /* CACHE_H */

--- a/cache.h
+++ b/cache.h
@@ -42,6 +42,7 @@ int git_deflate_abort(git_zstream *);
 int git_deflate_end_gently(git_zstream *);
 int git_deflate(git_zstream *, int flush);
 size_t git_deflate_bound(git_zstream *, size_t);
+uInt zlib_buf_cap(size_t len);
 
 /* The length in bytes and in hex digits of an object name (SHA-1 value). */
 #define GIT_SHA1_RAWSZ 20

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -386,6 +386,8 @@ ifeq ($(uname_S),Windows)
 	NO_POSIX_GOODIES = UnfortunatelyYes
 	NATIVE_CRLF = YesPlease
 	DEFAULT_HELP_FORMAT = html
+	NO_DEFLATE_BOUND = YesPlease
+	# the zlib.c deflateBound, compiled for windows, is limited to uLong 32bit sourceLen.
 
 	CC = compat/vcbuild/scripts/clink.pl
 	AR = compat/vcbuild/scripts/lib.pl

--- a/diff.c
+++ b/diff.c
@@ -3246,7 +3246,8 @@ static unsigned char *deflate_it(char *data,
 				 size_t size,
 				 size_t *result_size)
 {
-	int bound;
+	// FIXME
+	size_t bound;
 	unsigned char *deflated;
 	git_zstream stream;
 

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -965,6 +965,15 @@ static inline size_t xsize_t(off_t len)
 	return size;
 }
 
+static inline unsigned long ulong_t(size_t len)
+{
+	unsigned long size = (unsigned long) len;
+
+	if (len != (size_t) size)
+		die("Cannot handle files this big due to crappy unsigned long");
+	return size;
+}
+
 __attribute__((format (printf, 3, 4)))
 extern int xsnprintf(char *dst, size_t max, const char *fmt, ...);
 

--- a/http-push.c
+++ b/http-push.c
@@ -370,7 +370,7 @@ static void start_put(struct transfer_request *request)
 
 	/* Set it up */
 	git_deflate_init(&stream, zlib_compression_level);
-	size = git_deflate_bound(&stream, len + hdrlen);
+	size = git_deflate_bound(&stream, len + (size_t) hdrlen);
 	strbuf_init(&request->buffer.buf, size);
 	request->buffer.posn = 0;
 

--- a/http-push.c
+++ b/http-push.c
@@ -361,6 +361,7 @@ static void start_put(struct transfer_request *request)
 	void *unpacked;
 	size_t len;
 	int hdrlen;
+	// FIXME
 	ssize_t size;
 	git_zstream stream;
 

--- a/pack-check.c
+++ b/pack-check.c
@@ -37,7 +37,7 @@ int check_pack_crc(struct packed_git *p, struct pack_window **w_curs,
 		void *data = use_pack(p, w_curs, offset, &avail);
 		if (avail > len)
 			avail = len;
-		data_crc = crc32(data_crc, data, avail);
+		data_crc = xcrc32(data_crc, data, avail);
 		offset += avail;
 		len -= avail;
 	} while (len);

--- a/packfile.c
+++ b/packfile.c
@@ -1047,7 +1047,7 @@ struct list_head *get_packed_git_mru(struct repository *r)
 size_t unpack_object_header_buffer(const unsigned char *buf,
 		size_t len, enum object_type *type, size_t *sizep)
 {
-	unsigned shift;
+	size_t shift;
 	size_t size, c;
 	size_t used = 0;
 

--- a/packfile.c
+++ b/packfile.c
@@ -1056,7 +1056,8 @@ size_t unpack_object_header_buffer(const unsigned char *buf,
 	size = c & 15;
 	shift = 4;
 	while (c & 0x80) {
-		if (len <= used || bitsizeof(long) <= shift) {
+		if (len <= used) {
+			printf("type %d", type);
 			error("bad object header");
 			size = used = 0;
 			break;
@@ -1300,7 +1301,7 @@ static enum object_type packed_to_object_type(struct repository *r,
 	case OBJ_TAG:
 		break;
 	default:
-		error("unknown object type %i at offset %"PRIuMAX" in %s",
+		error("packed_to_object_type: unknown object type %i at offset %"PRIuMAX" in %s",
 		      type, (uintmax_t)obj_offset, p->pack_name);
 		type = OBJ_BAD;
 	}

--- a/t/README
+++ b/t/README
@@ -1025,6 +1025,8 @@ use these, and "test_set_prereq" for how to define your own.
 
    Git wasn't compiled with NO_PTHREADS=YesPlease.
 
+ FIXME Add SIZE_T_64BIT
+
 Tips for Writing Tests
 ----------------------
 

--- a/t/helper/test-tool.c
+++ b/t/helper/test-tool.c
@@ -60,6 +60,7 @@ static struct test_cmd cmds[] = {
 	{ "windows-named-pipe", cmd__windows_named_pipe },
 #endif
 	{ "write-cache", cmd__write_cache },
+	{ "zlib-compile-flags", cmd__zlib_compile_flags },
 };
 
 static NORETURN void die_usage(void)

--- a/t/helper/test-tool.h
+++ b/t/helper/test-tool.h
@@ -56,6 +56,7 @@ int cmd__wildmatch(int argc, const char **argv);
 int cmd__windows_named_pipe(int argc, const char **argv);
 #endif
 int cmd__write_cache(int argc, const char **argv);
+int cmd__zlib_compile_flags(int argc, const char **argv);
 
 int cmd_hash_impl(int ac, const char **av, int algo);
 

--- a/t/helper/test-zlib-compile-flags.c
+++ b/t/helper/test-zlib-compile-flags.c
@@ -1,0 +1,9 @@
+#include "test-tool.h"
+#include "git-compat-util.h"
+#include <zlib.h>
+
+int cmd__zlib_compile_flags(int argc, const char **argv)
+{
+	printf("%lu\n", zlibCompileFlags());
+	return 0;
+}

--- a/t/t-large-files-on-windows.sh
+++ b/t/t-large-files-on-windows.sh
@@ -5,6 +5,7 @@ test_description='test large file handling on windows'
 
 test_expect_success EXPENSIVE,SIZE_T_IS_64BIT 'blah blubb' '
 
+	test-tool zlib-compile-flags >zlibFlags.txt &&
 	dd if=/dev/zero of=file bs=1M count=4100 &&
 	git config core.compression 0 &&
 	git config core.looseCompression 0 &&

--- a/t/t-large-files-on-windows.sh
+++ b/t/t-large-files-on-windows.sh
@@ -12,7 +12,7 @@ test_expect_success EXPENSIVE,SIZE_T_IS_64BIT 'blah blubb' '
 	git commit -m msg file &&
 	git log --stat &&
 	git fsck --verbose --strict --full &&
-	git verify-pack .git/objects/pack/*.pack &&
+	git index-pack --verify .git/objects/pack/*.pack &&
 	git gc
 '
 

--- a/t/t-large-files-on-windows.sh
+++ b/t/t-large-files-on-windows.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+test_description='test large file handling on windows'
+. ./test-lib.sh
+
+test_expect_success SIZE_T_IS_64BIT 'blah blubb' '
+
+	dd if=/dev/zero of=file bs=1M count=4100 &&
+	git config core.compression 0 &&
+	git config core.looseCompression 0 &&
+	git add file &&
+	git commit -m msg file &&
+	git log --stat &&
+	git verify-pack .git/objects/pack/*.pack &&
+	git gc &&
+	git fsck
+'
+
+test_done

--- a/t/t-large-files-on-windows.sh
+++ b/t/t-large-files-on-windows.sh
@@ -6,13 +6,15 @@ test_description='test large file handling on windows'
 test_expect_success SIZE_T_IS_64BIT 'blah blubb' '
 
 	test-tool zlib-compile-flags >zlibFlags.txt &&
-	dd if=/dev/zero of=file bs=1M count=4 &&
+	dd if=/dev/zero of=file bs=1M count=5100 &&
 	git config core.compression 0 &&
 	git config core.looseCompression 0 &&
 	git add file &&
 	git fsck --verbose --strict --full &&
 	git commit -m msg file &&
 	git log --stat &&
+	git fsck --verbose --strict --full &&
+	git gc &&
 	git fsck --verbose --strict --full &&
 	git index-pack --verify .git/objects/pack/*.pack &&
 	git gc

--- a/t/t-large-files-on-windows.sh
+++ b/t/t-large-files-on-windows.sh
@@ -3,13 +3,14 @@
 test_description='test large file handling on windows'
 . ./test-lib.sh
 
-test_expect_success EXPENSIVE,SIZE_T_IS_64BIT 'blah blubb' '
+test_expect_success SIZE_T_IS_64BIT 'blah blubb' '
 
 	test-tool zlib-compile-flags >zlibFlags.txt &&
 	dd if=/dev/zero of=file bs=1M count=4 &&
 	git config core.compression 0 &&
 	git config core.looseCompression 0 &&
 	git add file &&
+	git fsck --verbose --strict --full &&
 	git commit -m msg file &&
 	git log --stat &&
 	git fsck --verbose --strict --full &&

--- a/t/t-large-files-on-windows.sh
+++ b/t/t-large-files-on-windows.sh
@@ -6,7 +6,7 @@ test_description='test large file handling on windows'
 test_expect_success EXPENSIVE,SIZE_T_IS_64BIT 'blah blubb' '
 
 	test-tool zlib-compile-flags >zlibFlags.txt &&
-	dd if=/dev/zero of=file bs=1M count=4100 &&
+	dd if=/dev/zero of=file bs=1M count=4 &&
 	git config core.compression 0 &&
 	git config core.looseCompression 0 &&
 	git add file &&

--- a/t/t-large-files-on-windows.sh
+++ b/t/t-large-files-on-windows.sh
@@ -16,7 +16,7 @@ test_expect_success SIZE_T_IS_64BIT 'blah blubb' '
 	git fsck --verbose --strict --full &&
 	git gc &&
 	git fsck --verbose --strict --full &&
-	git index-pack --verify .git/objects/pack/*.pack &&
+	git index-pack -v .git/objects/pack/*.pack &&
 	git gc
 '
 

--- a/t/t-large-files-on-windows.sh
+++ b/t/t-large-files-on-windows.sh
@@ -3,7 +3,7 @@
 test_description='test large file handling on windows'
 . ./test-lib.sh
 
-test_expect_success SIZE_T_IS_64BIT 'blah blubb' '
+test_expect_success EXPENSIVE,SIZE_T_IS_64BIT 'blah blubb' '
 
 	dd if=/dev/zero of=file bs=1M count=4100 &&
 	git config core.compression 0 &&
@@ -11,9 +11,9 @@ test_expect_success SIZE_T_IS_64BIT 'blah blubb' '
 	git add file &&
 	git commit -m msg file &&
 	git log --stat &&
+	git fsck --verbose --strict --full &&
 	git verify-pack .git/objects/pack/*.pack &&
-	git gc &&
-	git fsck
+	git gc
 '
 
 test_done

--- a/t/t-large-files-on-windows.sh
+++ b/t/t-large-files-on-windows.sh
@@ -10,13 +10,15 @@ test_expect_success SIZE_T_IS_64BIT 'blah blubb' '
 	git config core.compression 0 &&
 	git config core.looseCompression 0 &&
 	git add file &&
+	git verify-pack -s .git/objects/pack/*.pack &&
 	git fsck --verbose --strict --full &&
 	git commit -m msg file &&
+	git verify-pack -s .git/objects/pack/*.pack &&
 	git log --stat &&
 	git fsck --verbose --strict --full &&
-	git gc &&
-	git fsck --verbose --strict --full &&
-	git index-pack -v .git/objects/pack/*.pack &&
+	git repack -a -f &&
+	git verify-pack -s .git/objects/pack/*.pack &&
+	git verify-pack -v .git/objects/pack/*.pack &&
 	git gc
 '
 

--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -1555,6 +1555,10 @@ test_lazy_prereq LONG_IS_64BIT '
 	test 8 -le "$(build_option sizeof-long)"
 '
 
+test_lazy_prereq SIZE_T_IS_64BIT '
+	test 8 -le "$(build_option sizeof-size_t)"
+'
+
 test_lazy_prereq TIME_IS_64BIT 'test-tool date is64bit'
 test_lazy_prereq TIME_T_IS_64BIT 'test-tool date time_t-is64bit'
 

--- a/wrapper.c
+++ b/wrapper.c
@@ -704,13 +704,13 @@ int is_empty_or_missing_file(const char *filename)
 	return !st.st_size;
 }
 
-uLong xcrc32(uLong crc, const char *buf, size_t bytes)
+uLong xcrc32(uLong crc, const unsigned char *buf, size_t bytes)
 {
 	size_t bytes_rem, off;
 	bytes_rem = bytes;
 	off = 0;
-	while (bytes_rem > size_t(INTMAX_MAX) ) {
-		int crc_bytes = (bytes_rem > size_t(INTMAX_MAX)) ? size_t(INTMAX_MAX) : bytes_rem;
+	while (bytes_rem > (size_t)INTMAX_MAX) {
+		int crc_bytes = (bytes_rem > (size_t)INTMAX_MAX) ? (size_t)INTMAX_MAX : bytes_rem;
 		crc = crc32(crc, buf + off, crc_bytes);
 		off += crc_bytes;
 		bytes_rem -= crc_bytes;

--- a/wrapper.c
+++ b/wrapper.c
@@ -703,3 +703,17 @@ int is_empty_or_missing_file(const char *filename)
 
 	return !st.st_size;
 }
+
+uLong xcrc32(uLong crc, const char *buf, size_t bytes)
+{
+	size_t bytes_rem, off;
+	bytes_rem = bytes;
+	off = 0;
+	while (bytes_rem > size_t(INTMAX_MAX) ) {
+		int crc_bytes = (bytes_rem > size_t(INTMAX_MAX)) ? size_t(INTMAX_MAX) : bytes_rem;
+		crc = crc32(crc, buf + off, crc_bytes);
+		off += crc_bytes;
+		bytes_rem -= crc_bytes;
+	}
+	return crc;
+}

--- a/zlib.c
+++ b/zlib.c
@@ -38,26 +38,20 @@ static void zlib_pre_call(git_zstream *s)
 {
 	s->z.next_in = s->next_in;
 	s->z.next_out = s->next_out;
-	s->z.total_in = s->total_in;
-	s->z.total_out = s->total_out;
+	s->z.total_in = 0;
+	s->z.total_out = 0;
 	s->z.avail_in = zlib_buf_cap(s->avail_in);
 	s->z.avail_out = zlib_buf_cap(s->avail_out);
 }
 
 static void zlib_post_call(git_zstream *s)
 {
-	size_t bytes_consumed;
-	size_t bytes_produced;
-
-	bytes_consumed = s->z.next_in - s->next_in;
-	bytes_produced = s->z.next_out - s->next_out;
-
-	s->total_out += bytes_produced;
-	s->total_in += bytes_consumed;
+	s->total_out += (size_t) s->z.total_out;
+	s->total_in += (size_t) s->z.total_in;
 	s->next_in = s->z.next_in;
 	s->next_out = s->z.next_out;
-	s->avail_in -= bytes_consumed;
-	s->avail_out -= bytes_produced;
+	s->avail_in -= (size_t) s->z.total_in;
+	s->avail_out -= (size_t) s->z.total_out;
 }
 
 void git_inflate_init(git_zstream *strm)

--- a/zlib.c
+++ b/zlib.c
@@ -146,9 +146,13 @@ int git_inflate(git_zstream *strm, int flush)
 #define deflateBound(c,s)  ((s) + (((s) + 7) >> 3) + (((s) + 63) >> 6) + 11)
 #endif
 
+/*
+ * The zlib deflateBound() 'size' is uLong. Define NO_DEFLATE_BOUND on
+ * Windows where uLong is only 32 bits and would result in data loss.
+ */
 size_t git_deflate_bound(git_zstream *strm, size_t size)
 {
-	return deflateBound(&strm->z, ulong_t(size));
+	return deflateBound(&strm->z, size);
 }
 
 void git_deflate_init(git_zstream *strm, int level)

--- a/zlib.c
+++ b/zlib.c
@@ -28,7 +28,7 @@ static const char *zerr_to_string(int status)
  * with zlib in a single call to inflate/deflate.
  */
 /* #define ZLIB_BUF_MAX ((uInt)-1) */
-#define ZLIB_BUF_MAX ((uInt) 1024 * 1024 * 1024) /* 1GB */
+#define ZLIB_BUF_MAX ((uInt) 1 * 1024 * 1024) /* 1MB - for testing chunking code */
 static inline uInt zlib_buf_cap(size_t len)
 {
 	return (ZLIB_BUF_MAX < len) ? ZLIB_BUF_MAX : len;

--- a/zlib.c
+++ b/zlib.c
@@ -148,7 +148,7 @@ int git_inflate(git_zstream *strm, int flush)
 
 size_t git_deflate_bound(git_zstream *strm, size_t size)
 {
-	return deflateBound(&strm->z, size);
+	return deflateBound(&strm->z, ulong_t(size));
 }
 
 void git_deflate_init(git_zstream *strm, int level)

--- a/zlib.c
+++ b/zlib.c
@@ -31,7 +31,7 @@ static const char *zerr_to_string(int status)
 #define ZLIB_BUF_MAX ((uInt) 1 * 1024 * 1024) /* 1MB - for testing chunking code */
 static inline uInt zlib_buf_cap(size_t len)
 {
-	return (ZLIB_BUF_MAX < len) ? ZLIB_BUF_MAX : len;
+	return ((size_t) ZLIB_BUF_MAX < len) ? ZLIB_BUF_MAX : (uInt) len;
 }
 
 static void zlib_pre_call(git_zstream *s)
@@ -112,7 +112,7 @@ int git_inflate(git_zstream *strm, int flush)
 		zlib_pre_call(strm);
 		/* Never say Z_FINISH unless we are feeding everything */
 		status = inflate(&strm->z,
-				 (strm->z.avail_in != strm->avail_in)
+				 ((size_t) strm->z.avail_in != strm->avail_in)
 				 ? 0 : flush);
 		if (status == Z_MEM_ERROR)
 			die("inflate: out of memory");
@@ -238,7 +238,7 @@ int git_deflate(git_zstream *strm, int flush)
 
 		/* Never say Z_FINISH unless we are feeding everything */
 		status = deflate(&strm->z,
-				 (strm->z.avail_in != strm->avail_in)
+				 ((size_t) strm->z.avail_in != strm->avail_in)
 				 ? 0 : flush);
 		if (status == Z_MEM_ERROR)
 			die("deflate: out of memory");

--- a/zlib.c
+++ b/zlib.c
@@ -29,7 +29,7 @@ static const char *zerr_to_string(int status)
  */
 /* #define ZLIB_BUF_MAX ((uInt)-1) */
 #define ZLIB_BUF_MAX ((uInt) 1 * 1024 * 1024) /* 1MB - for testing chunking code */
-static inline uInt zlib_buf_cap(size_t len)
+inline uInt zlib_buf_cap(size_t len)
 {
 	return ((size_t) ZLIB_BUF_MAX < len) ? ZLIB_BUF_MAX : (uInt) len;
 }

--- a/zlib.c
+++ b/zlib.c
@@ -51,13 +51,9 @@ static void zlib_post_call(git_zstream *s)
 
 	bytes_consumed = s->z.next_in - s->next_in;
 	bytes_produced = s->z.next_out - s->next_out;
-	if (s->z.total_out != s->total_out + bytes_produced)
-		BUG("total_out mismatch");
-	if (s->z.total_in != s->total_in + bytes_consumed)
-		BUG("total_in mismatch");
 
-	s->total_out = s->z.total_out;
-	s->total_in = s->z.total_in;
+	s->total_out += bytes_produced;
+	s->total_in += bytes_consumed;
 	s->next_in = s->z.next_in;
 	s->next_out = s->z.next_out;
 	s->avail_in -= bytes_consumed;


### PR DESCRIPTION
Torsten, 
This is my extra coding done for the GfW >4GB effort. It still contains some debug code. It complies without error (simple `make'), but hasn't been converted to a GfW executable (AFAIU). 

I hope to try the [rebasing](https://github.com/git-for-windows/git/wiki/Rebasing-Git-for-Windows) to GfW tomorrow to see how it looks when run.

some of it is still hacky.